### PR TITLE
Feat: Add collateral transfer to treasury

### DIFF
--- a/src/external/token/ERC20Issuance_Blacklist_v1.sol
+++ b/src/external/token/ERC20Issuance_Blacklist_v1.sol
@@ -169,7 +169,10 @@ contract ERC20Issuance_Blacklist_v1 is
     }
 
     /// @inheritdoc IERC20Issuance_Blacklist_v1
-    function setBlacklistManager(address manager_, bool allowed_) external onlyOwner {
+    function setBlacklistManager(address manager_, bool allowed_)
+        external
+        onlyOwner
+    {
         _setBlacklistManager(manager_, allowed_);
     }
 

--- a/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
@@ -280,7 +280,7 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
     }
 
     /// @inheritdoc IFM_PC_ExternalPrice_Redeeming_v1
-    function getProjctTreasury() external view returns (address) {
+    function getProjectTreasury() external view returns (address) {
         return _projectTreasury;
     }
 

--- a/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
@@ -601,7 +601,7 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         // Process the protocol fee
         // Protocol fee is not charged for redemption in this implementation
         _processProtocolFeeViaTransfer(
-            collateralTreasury, collateralToken, protocolFeeAmount 
+            collateralTreasury, collateralToken, protocolFeeAmount
         );
 
         // Add project fee if applicable

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
@@ -132,7 +132,7 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
 
     /// @notice Gets the project treasury address
     /// @return address_ The address of the project treasury
-    function getProjctTreasury() external view returns (address);
+    function getProjectTreasury() external view returns (address);
 
     // --------------------------------------------------------------------------
     // External Functions

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
@@ -76,7 +76,10 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
     /// @notice	Thrown when a redemption queue execution fails
     error Module__FM_PC_ExternalPrice_Redeeming_QueueExecutionFailed();
 
-    // -------------------------------------------------------------------------
+    /// @notice Thrown when the project treasury address is invalid
+    error Module__FM_PC_ExternalPrice_Redeeming_InvalidProjectTreasury();
+
+    //--------------------------------------------------------------------------
     // Events
 
     /// @notice	Emitted when reserve tokens are deposited
@@ -127,7 +130,11 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
     /// @return	orderId_ The current order ID
     function getOrderId() external view returns (uint orderId_);
 
-    // -------------------------------------------------------------------------
+    /// @notice Gets the project treasury address
+    /// @return address_ The address of the project treasury
+    function getProjctTreasury() external view returns (address);
+
+    // --------------------------------------------------------------------------
     // External Functions
 
     /// @notice	Allows depositing collateral to provide reserves for redemptions
@@ -136,4 +143,8 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
 
     /// @notice	Executes the redemption queue
     function executeRedemptionQueue() external;
+
+    /// @notice Sets the project treasury address
+    /// @dev May revert with Module__FM_PC_ExternalPrice_Redeeming_InvalidProjectTreasury
+    function setProjectTreasury(address projectTreasury_) external;
 }

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
@@ -79,7 +79,7 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
     /// @notice Thrown when the project treasury address is invalid
     error Module__FM_PC_ExternalPrice_Redeeming_InvalidProjectTreasury();
 
-    //--------------------------------------------------------------------------
+    // --------------------------------------------------------------------------
     // Events
 
     /// @notice	Emitted when reserve tokens are deposited


### PR DESCRIPTION
## What has been done?
- Rebase locally from the Inverter feature branch
- Add treasury address to state, as well as setters for it
- overridden `_handleCollateralTokensBeforeBuy` to transfer collateral out of the contract during buy operations

**Please Note:** The branch `dev-1` first has to be rebased to resolve the merge conflicts