### PR TITLE
fix: remove oracle from init

### DIFF
--- a/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_ExternalPrice_Redeeming_v1.sol
@@ -162,7 +162,6 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
 
         // Decode config data
         (
-            address oracleAddress_,
             address projectTreasury_,
             address issuanceToken_,
             address acceptedToken_,
@@ -173,7 +172,7 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
             bool isDirectOperationsOnly_
         ) = abi.decode(
             configData_,
-            (address, address, address, address, uint, uint, uint, uint, bool)
+            (address, address, address, uint, uint, uint, uint, bool)
         );
 
         // Set accepted token
@@ -181,17 +180,6 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
 
         // Cache token decimals for collateral
         _collateralTokenDecimals = IERC20Metadata(address(_token)).decimals();
-
-        if (
-            !ERC165Upgradeable(address(oracleAddress_)).supportsInterface(
-                type(IOraclePrice_v1).interfaceId
-            )
-        ) {
-            revert Module__FM_PC_ExternalPrice_Redeeming_InvalidOracleInterface(
-            );
-        }
-        // Set oracle
-        _oracle = IOraclePrice_v1(oracleAddress_);
 
         // Initialize base functionality (should handle token settings)
         _setIssuanceToken(issuanceToken_);
@@ -432,6 +420,11 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         onlyOrchestratorAdmin
     {
         _setProjectTreasury(projectTreasury_);
+    }
+
+    /// @inheritdoc IFM_PC_ExternalPrice_Redeeming_v1
+    function setOracleAddress(address oracle_) external onlyOrchestratorAdmin {
+        _setOracleAddress(oracle_);
     }
 
     /// @notice Gets current buy fee.
@@ -696,6 +689,21 @@ contract FM_PC_ExternalPrice_Redeeming_v1 is
         issuanceToken = IERC20Issuance_v1(issuanceToken_);
         _issuanceTokenDecimals = decimals_;
         emit IssuanceTokenSet(issuanceToken_, decimals_);
+    }
+
+    /// @notice Sets the oracle address
+    /// @dev May revert with Module__FM_PC_ExternalPrice_Redeeming_InvalidOracleInterface
+    /// @param oracleAddress_ The address of the oracle
+    function _setOracleAddress(address oracleAddress_) internal {
+        if (
+            !ERC165Upgradeable(address(oracleAddress_)).supportsInterface(
+                type(IOraclePrice_v1).interfaceId
+            )
+        ) {
+            revert Module__FM_PC_ExternalPrice_Redeeming_InvalidOracleInterface(
+            );
+        }
+        _oracle = IOraclePrice_v1(oracleAddress_);
     }
 
     /// @notice Sets the project treasury address

--- a/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/interfaces/IFM_PC_ExternalPrice_Redeeming_v1.sol
@@ -147,4 +147,9 @@ interface IFM_PC_ExternalPrice_Redeeming_v1 is
     /// @notice Sets the project treasury address
     /// @dev May revert with Module__FM_PC_ExternalPrice_Redeeming_InvalidProjectTreasury
     function setProjectTreasury(address projectTreasury_) external;
+
+    /// @notice Sets the oracle address
+    /// @dev May revert with Module__FM_PC_ExternalPrice_Redeeming_InvalidOracleInterface
+    /// @param oracle_ The address of the oracle
+    function setOracleAddress(address oracle_) external;
 }


### PR DESCRIPTION
## What has been done?
- Remove the oracle address setting from the init
- Add setters for the oracle (internal & external)

## Why has this been changes
Initially the Oracle was an external contract. This would enable us to just give the address during the workflow deployment. 

However we moved away from having the oracle to be an external contract and instead made it a module. This has the effect that we cannot know the modules address during deployment, as all of the workflow deployment happens in one transaction.

For that reason the oracle address needs to be set after init. 