### PR TITLE
PP_Queue_v1 Test Refactor

### DIFF
--- a/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
+++ b/src/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.sol
@@ -202,28 +202,28 @@ contract FM_PC_Oracle_Redeeming_v1 is
     // Constants
 
     /// @notice Role identifier for accounts who are whitelisted to buy and sell.
-    bytes32 private constant WHITELIST_ROLE = "WHITELIST_ROLE";
+    bytes32 internal constant WHITELIST_ROLE = "WHITELIST_ROLE";
 
     /// @notice Role identifier for the admin authorized to assign the whitelist
     ///         role.
     /// @dev    This role should be set as the role admin for the WHITELIST_ROLE
     ///         within the Authorizer module.
-    bytes32 private constant WHITELIST_ROLE_ADMIN = "WHITELIST_ROLE_ADMIN";
+    bytes32 internal constant WHITELIST_ROLE_ADMIN = "WHITELIST_ROLE_ADMIN";
 
     /// @notice Role identifier for accounts who are allowed to manually execute
     ///         the redemption queue.
-    bytes32 private constant QUEUE_EXECUTOR_ROLE = "QUEUE_EXECUTOR_ROLE";
+    bytes32 internal constant QUEUE_EXECUTOR_ROLE = "QUEUE_EXECUTOR_ROLE";
 
     /// @notice Role identifier for the admin authorized to assign the queue
     ///         execution role.
     ///         role.
     /// @dev    This role should be set as the role admin for the
     ///         QUEUE_EXECUTOR_ROLE within the Authorizer module.
-    bytes32 private constant QUEUE_EXECUTOR_ROLE_ADMIN =
+    bytes32 internal constant QUEUE_EXECUTOR_ROLE_ADMIN =
         "QUEUE_EXECUTOR_ROLE_ADMIN";
 
     /// @notice Flag used for the payment order.
-    uint private constant FLAG_ORDER_ID = 0;
+    uint internal constant FLAG_ORDER_ID = 0;
 
     // -------------------------------------------------------------------------
     // State Variables
@@ -231,49 +231,49 @@ contract FM_PC_Oracle_Redeeming_v1 is
     /// @notice Oracle price feed contract used for price discovery.
     /// @dev    Contract that provides external price information for token
     ///         valuation.
-    IOraclePrice_v1 private _oracle;
+    IOraclePrice_v1 internal _oracle;
 
     /// @notice Token that is accepted by this funding manager for deposits.
     /// @dev    The ERC20 token contract used for collateral in this funding
     ///         manager.
-    IERC20 private _token;
+    IERC20 internal _token;
 
     /// @notice Token decimals of the issuance token.
     /// @dev    Number of decimal places used by the issuance token for proper
     ///         decimal handling.
-    uint8 private _issuanceTokenDecimals;
+    uint8 internal _issuanceTokenDecimals;
 
     /// @notice Token decimals of the Orchestrator token.
     /// @dev    Number of decimal places used by the collateral token for proper
     ///         decimal handling.
-    uint8 private _collateralTokenDecimals;
+    uint8 internal _collateralTokenDecimals;
 
     /// @notice Maximum fee that can be charged for sell operations, in base
     ///         points.
     /// @dev    Maximum allowed project fee percentage that can be charged when
     ///         selling tokens.
-    uint private _maxProjectSellFee;
+    uint internal _maxProjectSellFee;
 
     /// @notice Maximum fee that can be charged for buy operations, in base
     ///         points.
     /// @dev    Maximum allowed project fee percentage for buying tokens.
-    uint private _maxProjectBuyFee;
+    uint internal _maxProjectBuyFee;
 
     /// @notice Order ID counter for tracking individual orders.
     /// @dev    Unique identifier for the current order being processed.
-    uint private _orderId;
+    uint internal _orderId;
 
     /// @notice Total amount of collateral tokens currently in redemption
     ///         process.
     /// @dev    Tracks the sum of all pending redemption orders.
-    uint private _openRedemptionAmount;
+    uint internal _openRedemptionAmount;
 
     /// @notice Flag indicating if direct operations are only allowed.
     bool internal _isDirectOperationsOnly;
 
     /// @notice Address of the project treasury which will receive the
     ///         collateral tokens.
-    address private _projectTreasury;
+    address internal _projectTreasury;
 
     // -------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/logicModule/LM_Oracle_Permissioned_v1.sol
+++ b/src/modules/logicModule/LM_Oracle_Permissioned_v1.sol
@@ -109,26 +109,27 @@ contract LM_Oracle_Permissioned_v1 is ILM_Oracle_Permissioned_v1, Module_v1 {
 
     /// @notice Role identifier for accounts authorized to set prices.
     /// @dev    This role should be granted to trusted price feeders only.
-    bytes32 private constant PRICE_SETTER_ROLE = "PRICE_SETTER_ROLE";
+    bytes32 internal constant PRICE_SETTER_ROLE = "PRICE_SETTER_ROLE";
 
     /// @notice Role identifier for the admin authorized to assign the price
     ///         setter role.
     /// @dev    This role should be set as the role admin within the Authorizer
     ///         module.
-    bytes32 private constant PRICE_SETTER_ROLE_ADMIN = "PRICE_SETTER_ROLE_ADMIN";
+    bytes32 internal constant PRICE_SETTER_ROLE_ADMIN =
+        "PRICE_SETTER_ROLE_ADMIN";
 
     // -------------------------------------------------------------------------
     // State Variables
 
     /// @notice The price for issuing tokens (in collateral token decimals)
-    uint private _issuancePrice;
+    uint internal _issuancePrice;
 
     /// @notice The price for redeeming tokens (in collateral token decimals)
-    uint private _redemptionPrice;
+    uint internal _redemptionPrice;
 
     /// @notice Decimals of the collateral token (e.g., USDC with 6 decimals).
     /// @dev    This is the token used to pay/buy with.
-    uint8 private _collateralTokenDecimals;
+    uint8 internal _collateralTokenDecimals;
 
     // -------------------------------------------------------------------------
     // Initialization

--- a/src/modules/paymentProcessor/PP_Queue_v1.sol
+++ b/src/modules/paymentProcessor/PP_Queue_v1.sol
@@ -123,34 +123,34 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     // Constants
 
     /// @notice    Flag position in the flags byte.
-    uint8 private constant FLAG_ORDER_ID = 0;
+    uint8 internal constant FLAG_ORDER_ID = 0;
 
     /// @notice Role identifier for queue operations.
     /// @dev    This role cancels payments in the queue.
-    bytes32 private constant QUEUE_OPERATOR_ROLE = "QUEUE_OPERATOR_ROLE";
+    bytes32 internal constant QUEUE_OPERATOR_ROLE = "QUEUE_OPERATOR_ROLE";
 
     /// @notice Role identifier for the admin authorized to assign the queue
     ///         operator role.
     /// @dev    This role should be set as the role admin for the
     ///         QUEUE_OPERATOR_ROLE within the Authorizer module.
-    bytes32 private constant QUEUE_OPERATOR_ROLE_ADMIN =
+    bytes32 internal constant QUEUE_OPERATOR_ROLE_ADMIN =
         "QUEUE_OPERATOR_ROLE_ADMIN";
 
     /// @notice BPS value.
-    uint private constant BPS = 10_000;
+    uint internal constant BPS = 10_000;
 
     // -------------------------------------------------------------------------
     // Storage
 
     /// @notice Queue of payment orders per client.
-    mapping(address client => LinkedIdList.List queue) private _queue;
+    mapping(address client => LinkedIdList.List queue) internal _queue;
 
     /// @notice Payment orders.
     mapping(address client => mapping(uint orderId => QueuedOrder order))
-        private _orders;
+        internal _orders;
 
     /// @notice Current order ID per client.
-    mapping(address client => uint currentOrderId) private _currentOrderId;
+    mapping(address client => uint currentOrderId) internal _currentOrderId;
 
     /// @notice Tracks all payments that could not be made to the
     ///         paymentReceiver.
@@ -160,13 +160,13 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
                 address token
                     => mapping(address receiver => uint unclaimableAmount)
             )
-    ) private _unclaimableAmountsForRecipient;
+    ) internal _unclaimableAmountsForRecipient;
 
     /// @notice Treasury address which receives the collateral of canceled orders.
-    address private _cancelledOrdersTreasury;
+    address internal _cancelledOrdersTreasury;
 
     /// @notice Treasury address which receives the collateral of failed orders.
-    address private _failedOrdersTreasury;
+    address internal _failedOrdersTreasury;
 
     // -------------------------------------------------------------------------
     // Modifiers
@@ -527,7 +527,7 @@ contract PP_Queue_v1 is IPP_Queue_v1, Module_v1 {
     ///         cases the order is removed from the queue.
     /// @param	orderId_ The ID of the order to process.
     /// @param	order_ The order to process.
-    function _executePaymentTransfer(uint orderId_, QueuedOrder storage order_)
+    function _executePaymentTransfer(uint orderId_, QueuedOrder memory order_)
         internal
         virtual
     {

--- a/test/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
+++ b/test/modules/fundingManager/oracle/FM_PC_Oracle_Redeeming_v1.t.sol
@@ -1259,6 +1259,7 @@ contract FM_PC_ExternalPrice_Redeeming_v1_Test is ModuleTest {
     ) public {
         // Setup
         vm.assume(recipient_ != address(0));
+        vm.assume(recipient_ != address(projectTreasury));
         vm.assume(amount_ > 0);
         _prepareBuyOrSellConditions(
             address(_token), amount_, recipient_, address(fundingManager)

--- a/test/modules/paymentProcessor/PP_Queue_ManualExecution_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_ManualExecution_v1.t.sol
@@ -89,7 +89,8 @@ contract PP_Queue_ManualExecution_v1_Test is PP_Queue_v1_Test {
         uint originChainId = block.chainid;
         uint targetChainId = block.chainid;
 
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient,
@@ -184,7 +185,8 @@ contract PP_Queue_ManualExecution_v1_Test is PP_Queue_v1_Test {
         uint originChainId = block.chainid;
         uint targetChainId = block.chainid;
 
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
         IERC20PaymentClientBase_v2.PaymentOrder({

--- a/test/modules/paymentProcessor/PP_Queue_ManualExecution_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_ManualExecution_v1.t.sol
@@ -89,8 +89,7 @@ contract PP_Queue_ManualExecution_v1_Test is PP_Queue_v1_Test {
         uint originChainId = block.chainid;
         uint targetChainId = block.chainid;
 
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient,
@@ -185,8 +184,7 @@ contract PP_Queue_ManualExecution_v1_Test is PP_Queue_v1_Test {
         uint originChainId = block.chainid;
         uint targetChainId = block.chainid;
 
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
         IERC20PaymentClientBase_v2.PaymentOrder({

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -604,7 +604,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
@@ -645,7 +645,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         amount_ = uint96(bound(uint(amount_), 1, 1e30));
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         helper_setupPaymentTokenBalanceAndApproval(amount_);
 
@@ -795,7 +795,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
@@ -822,7 +822,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             uint96 amount_ = 100;
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order =
-                _createTestPaymentOrder(recipient_, amount_, i_ + 1);
+                helper_createTestPaymentOrder(recipient_, amount_, i_ + 1);
 
             helper_setupPaymentTokenBalanceAndApproval(amount_);
 
@@ -1513,7 +1513,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         // Setup tokens using helper
         helper_setupPaymentTokenBalanceAndApproval(amount_);
@@ -1571,7 +1571,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         // Setup tokens using helper
         helper_setupPaymentTokenBalanceAndApproval(amount_);
@@ -1804,7 +1804,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
@@ -1840,7 +1840,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
@@ -2140,7 +2140,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         _token.mint(address(paymentClient), amount_ * 2);
 
@@ -2668,7 +2668,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount = 1000;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
-            _createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1);
         // Setup initial state
         _token.mint(address(paymentClient), amount);
         paymentClient.exposed_addToOutstandingTokenAmounts(
@@ -2728,7 +2728,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount = 1000;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
-            _createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1);
 
         // Setup initial state
         _token.mint(address(paymentClient), amount);
@@ -2796,7 +2796,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         _token.mint(address(paymentClient), amount_ * 2);
 
@@ -2841,7 +2841,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            _createTestPaymentOrder(recipient_, amount_, 1);
+            helper_createTestPaymentOrder(recipient_, amount_, 1);
 
         _token.mint(address(paymentClient), amount_ * 2);
 
@@ -2980,7 +2980,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
         IERC20PaymentClientBase_v2.PaymentOrder memory validOrder =
-            _createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1);
 
         assertTrue(
             queue.validPaymentOrder(validOrder),
@@ -2988,14 +2988,14 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
 
         IERC20PaymentClientBase_v2.PaymentOrder memory invalidOrder =
-            _createTestPaymentOrder(address(0), amount, 1);
+            helper_createTestPaymentOrder(address(0), amount, 1);
 
         assertFalse(
             queue.validPaymentOrder(invalidOrder),
             "Payment order with zero address recipient should return false"
         );
 
-        invalidOrder = _createTestPaymentOrder(recipient, 0, 1);
+        invalidOrder = helper_createTestPaymentOrder(recipient, 0, 1);
 
         assertFalse(
             queue.validPaymentOrder(invalidOrder),
@@ -3490,7 +3490,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Now add it as unclaimable
         queue.exposed_addUnclaimableOrder(
-            _createTestPaymentOrder(recipient, amount, 1),
+            helper_createTestPaymentOrder(recipient, amount, 1),
             address(paymentClient)
         );
 
@@ -3546,7 +3546,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             helper__encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory validOrder =
-            _createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1);
 
         assertTrue(
             queue.exposed_validPaymentOrder(validOrder),
@@ -3557,7 +3557,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     // ================================================================================
     // Helper Functions
 
-    function _createTestPaymentOrder(
+    function helper_createTestPaymentOrder(
         address recipient,
         uint96 amount,
         uint orderNum

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -3181,18 +3181,23 @@ contract PP_Queue_v1_Test is ModuleTest {
         address client = makeAddr("client");
         address recipient = makeAddr("recipient");
         uint amount = 100;
+        // Setup
+        address invalidRecipient = makeAddr("invalidRecipient");
+        vm.assume(amount > 0);
+        // initiate token and set fail transfer to invalid recipient
+        NonStandardTokenMock nonStandardToken = new NonStandardTokenMock();
+        nonStandardToken.setFailTransferTo(invalidRecipient);
+        // mint tokens to payment client and approve queue to spend
+        nonStandardToken.mint(address(paymentClient), amount);
+        vm.prank(address(paymentClient));
+        nonStandardToken.approve(address(queue), amount);
 
-        // Test with non-ERC20 contract
-        address nonERC20Contract = address(new NonERC20Contract());
         bool success = queue.exposed_lowLevelTransfer(
-            nonERC20Contract, client, recipient, amount
+            address(nonStandardToken), client, recipient, amount
         );
         assertFalse(success, "Transfer should fail with non-ERC20 contract");
-
-        // Test with contract that doesn't implement transferFrom
-        address invalidContract = address(new InvalidTransferContract());
         success = queue.exposed_lowLevelTransfer(
-            invalidContract, client, recipient, amount
+            address(nonStandardToken), client, recipient, amount
         );
         assertFalse(
             success, "Transfer should fail with invalid transfer contract"
@@ -3255,74 +3260,6 @@ contract PP_Queue_v1_Test is ModuleTest {
             abi.encodeWithSignature("Module__PP_Queue_OnlyCallableByClient()")
         );
         queue.exposed_ensureValidClient(client_);
-    }
-
-    // ================================================================================
-    // Helper Functions
-
-    function _createTestPaymentOrder(
-        address recipient,
-        uint96 amount,
-        uint orderNum
-    ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
-        (bytes32 flags, bytes32[] memory data) =
-            helper_encodePaymentOrderData(orderNum);
-        return IERC20PaymentClientBase_v2.PaymentOrder({
-            recipient: recipient,
-            amount: amount,
-            paymentToken: address(_token),
-            originChainId: block.chainid,
-            targetChainId: block.chainid,
-            flags: flags,
-            data: data
-        });
-    }
-
-    function _setupPaymentTokenBalanceAndApproval(uint96 amount) internal {
-        _token.mint(address(paymentClient), amount);
-        paymentClient.exposed_addToOutstandingTokenAmounts(
-            address(_token), amount
-        );
-        vm.prank(address(paymentClient));
-        _token.approve(address(queue), amount);
-    }
-
-    function _assertOrderMatch(
-        uint orderId,
-        address client,
-        address expectedRecipient,
-        uint expectedAmount,
-        IPP_Queue_v1.RedemptionState expectedState
-    ) internal {
-        IPP_Queue_v1.QueuedOrder memory queuedOrder =
-            queue.getOrder(orderId, IERC20PaymentClientBase_v2(client));
-        assertEq(
-            queuedOrder.order_.recipient, expectedRecipient, "Wrong recipient"
-        );
-        assertEq(queuedOrder.order_.amount, expectedAmount, "Wrong amount");
-        assertEq(
-            queuedOrder.order_.paymentToken, address(_token), "Wrong token"
-        );
-        assertEq(uint(queuedOrder.state_), uint(expectedState), "Wrong state");
-    }
-
-    function helper_encodePaymentOrderData(uint orderId_)
-        internal
-        pure
-        returns (bytes32 flags_, bytes32[] memory data_)
-    {
-        bytes32 _flags;
-        _flags = 0;
-
-        uint8[] memory flags = new uint8[](1); // The Module will use 1 flag
-        flags[0] = 0;
-
-        _flags |= bytes32((1 << flags[0]));
-
-        bytes32[] memory paymentParameters = new bytes32[](1);
-        paymentParameters[0] = bytes32(orderId_);
-
-        return (_flags, paymentParameters);
     }
 
     /* Test testSetCanceledOrdersTreasury_GivenValidAddress()
@@ -3455,20 +3392,121 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         assertFalse(queue.exposed_validateFlagsAndData(flags, data));
     }
-}
 
-// Mock contracts for testing
-contract NonERC20Contract {
-// This contract doesn't implement any ERC20 functions
-}
+    /* Test testValidStateTransition_RevertGivenInvalidTransition()
+        └── Given an invalid state transition
+            └── When validating the state transition
+                └── Then it should revert with Module__PP_Queue_InvalidStateTransition
+    */
+    function testValidStateTransition_RevertGivenInvalidTransition() public {
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "Module__PP_Queue_InvalidStateTransition(uint256,uint8,uint8)",
+                1,
+                uint8(IPP_Queue_v1.RedemptionState.PROCESSED),
+                uint8(IPP_Queue_v1.RedemptionState.PENDING)
+            )
+        );
+        queue.exposed_validStateTransition(
+            1,
+            IPP_Queue_v1.RedemptionState.PROCESSED,
+            IPP_Queue_v1.RedemptionState.PENDING
+        );
+    }
 
-contract InvalidTransferContract {
-    // This contract implements transferFrom but returns false
-    function transferFrom(address, address, uint)
-        external
+    /* Test testValidStateTransition_SucceedsGivenValidTransitions()
+        └── Given valid state transitions
+            └── When validating the state transitions
+                └── Then they should succeed
+    */
+    function testValidStateTransition_SucceedsGivenValidTransitions() public {
+        // PENDING -> PROCESSED
+        queue.exposed_validStateTransition(
+            1,
+            IPP_Queue_v1.RedemptionState.PENDING,
+            IPP_Queue_v1.RedemptionState.PROCESSED
+        );
+
+        // PENDING -> CANCELLED
+        queue.exposed_validStateTransition(
+            1,
+            IPP_Queue_v1.RedemptionState.PENDING,
+            IPP_Queue_v1.RedemptionState.CANCELLED
+        );
+
+        // PENDING -> FAILED
+        queue.exposed_validStateTransition(
+            1,
+            IPP_Queue_v1.RedemptionState.PENDING,
+            IPP_Queue_v1.RedemptionState.FAILED
+        );
+    }
+
+    // ================================================================================
+    // Helper Functions
+
+    function _createTestPaymentOrder(
+        address recipient,
+        uint96 amount,
+        uint orderNum
+    ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
+        (bytes32 flags, bytes32[] memory data) =
+            helper_encodePaymentOrderData(orderNum);
+        return IERC20PaymentClientBase_v2.PaymentOrder({
+            recipient: recipient,
+            amount: amount,
+            paymentToken: address(_token),
+            originChainId: block.chainid,
+            targetChainId: block.chainid,
+            flags: flags,
+            data: data
+        });
+    }
+
+    function _setupPaymentTokenBalanceAndApproval(uint96 amount) internal {
+        _token.mint(address(paymentClient), amount);
+        paymentClient.exposed_addToOutstandingTokenAmounts(
+            address(_token), amount
+        );
+        vm.prank(address(paymentClient));
+        _token.approve(address(queue), amount);
+    }
+
+    function _assertOrderMatch(
+        uint orderId,
+        address client,
+        address expectedRecipient,
+        uint expectedAmount,
+        IPP_Queue_v1.RedemptionState expectedState
+    ) internal {
+        IPP_Queue_v1.QueuedOrder memory queuedOrder =
+            queue.getOrder(orderId, IERC20PaymentClientBase_v2(client));
+        assertEq(
+            queuedOrder.order_.recipient, expectedRecipient, "Wrong recipient"
+        );
+        assertEq(queuedOrder.order_.amount, expectedAmount, "Wrong amount");
+        assertEq(
+            queuedOrder.order_.paymentToken, address(_token), "Wrong token"
+        );
+        assertEq(uint(queuedOrder.state_), uint(expectedState), "Wrong state");
+    }
+
+    function helper_encodePaymentOrderData(uint orderId_)
+        internal
         pure
-        returns (bool)
+        returns (bytes32 flags_, bytes32[] memory data_)
     {
-        return false;
+        bytes32 _flags;
+        _flags = 0;
+
+        uint8[] memory flags = new uint8[](1); // The Module will use 1 flag
+        flags[0] = 0;
+
+        _flags |= bytes32((1 << flags[0]));
+
+        bytes32[] memory paymentParameters = new bytes32[](1);
+        paymentParameters[0] = bytes32(orderId_);
+
+        return (_flags, paymentParameters);
     }
 }

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -3474,6 +3474,52 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Recipient should receive tokens"
         );
     }
+    /* Test testValidPaymentOrder_RevertGivenInvalidTargetChain()
+        └── Given a payment order with an invalid target chain
+            └── When validating the payment order
+                └── Then it should revert with Module__PP_Queue_InvalidTargetChain
+    */
+
+    function test_validPaymentOrder_failsWithInvalidTargetChain() public {
+        address recipient = makeAddr("recipient");
+        uint96 amount = 100;
+        (bytes32 flags, bytes32[] memory data) = _encodePaymentOrderData(1);
+
+        IERC20PaymentClientBase_v2.PaymentOrder memory invalidOrder =
+        IERC20PaymentClientBase_v2.PaymentOrder({
+            recipient: recipient,
+            amount: amount,
+            paymentToken: address(_token),
+            originChainId: block.chainid,
+            targetChainId: block.chainid + 1, // Invalid target chain
+            flags: flags,
+            data: data
+        });
+
+        assertFalse(
+            queue.exposed_validPaymentOrder(invalidOrder),
+            "Payment order with invalid target chain should return false"
+        );
+    }
+    /* Test testValidPaymentOrder_SucceedsGivenValidOrder()
+        └── Given a valid payment order
+            └── When validating the payment order
+                └── Then it should return true
+    */
+
+    function test_validPaymentOrder_succeedsWithValidOrder() public {
+        address recipient = makeAddr("recipient");
+        uint96 amount = 100;
+        (bytes32 flags, bytes32[] memory data) = _encodePaymentOrderData(1);
+
+        IERC20PaymentClientBase_v2.PaymentOrder memory validOrder =
+            _createTestPaymentOrder(recipient, amount, 1);
+
+        assertTrue(
+            queue.exposed_validPaymentOrder(validOrder),
+            "Payment order with valid target chain should return true"
+        );
+    }
 
     // ================================================================================
     // Helper Functions

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -3097,15 +3097,10 @@ contract PP_Queue_v1_Test is ModuleTest {
                 └── Then zero chain ID should return false
     */
 
-    function testValidChainId_GivenValidAndInvalidIds(uint chainId_) public {
-        // Bound the chainId to a reasonable range to avoid overflow
+    function testInternalValidChainId_RevertsGivenInvalidIds(uint chainId_)
+        public
+    {
         chainId_ = bound(chainId_, 0, type(uint128).max);
-
-        // Test current chain ID
-        assertTrue(
-            queue.exposed_validChainId(block.chainid),
-            "Current chain ID should be valid"
-        );
 
         // Test different chain ID
         vm.assume(chainId_ != block.chainid);
@@ -3120,6 +3115,19 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
     }
 
+    /* Test testValidChainId_GivenInvalidChainId()
+        └── Given an invalid chain ID
+            └── When validating the chain ID
+                └── Then it should revert
+    */
+    function testInternalValidChainId_worksGivenValidChainId() public {
+        // Test current chain ID
+        assertTrue(
+            queue.exposed_validChainId(block.chainid),
+            "Current chain ID should be valid"
+        );
+    }
+
     /* Test testLowLevelTransfer_GivenValidInputs()
         └── Given valid transfer inputs
             └── When performing low level transfer
@@ -3128,7 +3136,7 @@ contract PP_Queue_v1_Test is ModuleTest {
                 ├── Then non-contract token should fail
                 └── Then zero address token should fail
     */
-    function testLowLevelTransfer_GivenValidInputs() public {
+    function testInternalLowLevelTransfer_worksGivenValidInputs() public {
         // Setup
         address client = makeAddr("client");
         address recipient = makeAddr("recipient");
@@ -3176,7 +3184,7 @@ contract PP_Queue_v1_Test is ModuleTest {
                 ├── Then non-ERC20 contract should fail
                 └── Then invalid transfer contract should fail
     */
-    function testLowLevelTransfer_GivenInvalidToken() public {
+    function testInternalLowLevelTransfer_RevertsGivenInvalidToken() public {
         // Setup
         address client = makeAddr("client");
         address recipient = makeAddr("recipient");
@@ -3204,9 +3212,6 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
     }
 
-    // ================================================================================
-    // Test Ensure Valid Client
-
     /* Test testEnsureValidClient_GivenValidClient()
         └── Given a valid client address that is:
             ├── Not address(0)
@@ -3215,7 +3220,9 @@ contract PP_Queue_v1_Test is ModuleTest {
                 └── When caller is the client
                     └── Then it should succeed
     */
-    function testEnsureValidClient_GivenValidClient(address client_) public {
+    function testInternalEnsureValidClient_worksGivenValidClient(
+        address client_
+    ) public {
         vm.assume(client_ != address(0));
         vm.assume(client_ != address(queue));
         vm.assume(client_ != address(_orchestrator));
@@ -3231,7 +3238,7 @@ contract PP_Queue_v1_Test is ModuleTest {
                 ├── Then it should revert with Module__PP_Queue_InvalidClientAddress for zero address
                 └── Then it should revert with Module__PP_Queue_InvalidClientAddress for queue address
     */
-    function testEnsureValidClient_RevertGivenInvalidClient() public {
+    function testInternalEnsureValidClient_RevertGivenInvalidClient() public {
         vm.expectRevert();
         queue.exposed_ensureValidClient(address(0));
 
@@ -3245,7 +3252,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When caller is not the client
                 └── Then it should revert with Module__PP_Queue_OnlyCallableByClient
     */
-    function testEnsureValidClient_RevertGivenNonClientCaller(
+    function testInternalEnsureValidClient_RevertGivenNonClientCaller(
         address client_,
         address caller_
     ) public {
@@ -3267,7 +3274,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When setting the canceled orders treasury
                 └── Then it should be set correctly
     */
-    function testSetCanceledOrdersTreasury_GivenValidAddress() public {
+    function testInternalSetCanceledOrdersTreasury_worksGivenValidAddress()
+        public
+    {
         address newTreasury = makeAddr("newTreasury");
 
         queue.exposed_setCanceledOrdersTreasury(newTreasury);
@@ -3285,7 +3294,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When setting the canceled orders treasury
                 └── Then it should revert
     */
-    function testSetCanceledOrdersTreasury_RevertGivenZeroAddress() public {
+    function testInternalSetCanceledOrdersTreasury_RevertGivenZeroAddress()
+        public
+    {
         vm.expectRevert(
             abi.encodeWithSignature(
                 "Module__PP_Queue_InvalidTreasuryAddress(address)", address(0)
@@ -3299,7 +3310,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When setting the failed orders treasury
                 └── Then it should be set correctly
     */
-    function testSetFailedOrdersTreasury_GivenValidAddress() public {
+    function testInternalSetFailedOrdersTreasury_worksGivenValidAddress()
+        public
+    {
         address newTreasury = makeAddr("newTreasury");
 
         queue.exposed_setFailedOrdersTreasury(newTreasury);
@@ -3317,7 +3330,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When setting the failed orders treasury
                 └── Then it should revert
     */
-    function testSetFailedOrdersTreasury_RevertGivenZeroAddress() public {
+    function testInternalSetFailedOrdersTreasury_RevertGivenZeroAddress()
+        public
+    {
         vm.expectRevert(
             abi.encodeWithSignature(
                 "Module__PP_Queue_InvalidTreasuryAddress(address)", address(0)
@@ -3331,7 +3346,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And the token is not address(0)
                 └── Then it should return true
     */
-    function testEnsureValidPaymentToken_SucceedsGivenValidToken() public {
+    function testInternalEnsureValidPaymentToken_worksGivenValidToken()
+        public
+    {
         assertTrue(queue.exposed_validPaymentToken(address(_token)));
     }
 
@@ -3340,7 +3357,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When ensuring valid payment token
                 └── Then it should revert
     */
-    function testEnsureValidPaymentToken_RevertGivenInvalidToken() public {
+    function testInternalEnsureValidPaymentToken_RevertGivenInvalidToken()
+        public
+    {
         assertFalse(queue.exposed_validPaymentToken(address(0)));
     }
 
@@ -3349,7 +3368,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And data array with order ID
                 └── Then it should return true
     */
-    function testValidateFlagsAndData_SucceedsGivenValidFlagsAndData() public {
+    function testInternalValidateFlagsAndData_worksGivenValidFlagsAndData()
+        public
+    {
         bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
         bytes32[] memory data = new bytes32[](1);
         data[0] = bytes32(uint(123)); // Some order ID
@@ -3362,7 +3383,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And empty data array
                 └── Then it should return true
     */
-    function testValidateFlagsAndData_SucceedsGivenValidFlagsWithoutData()
+    function testInternalValidateFlagsAndData_worksGivenValidFlagsWithoutData()
         public
     {
         bytes32 flags = bytes32(uint(0)); // No bits set
@@ -3376,7 +3397,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And empty data array
                 └── Then it should return false
     */
-    function testValidateFlagsAndData_FailsGivenInvalidFlagsWithData() public {
+    function testInternalValidateFlagsAndData_FailsGivenInvalidFlagsWithData()
+        public
+    {
         bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
         bytes32[] memory data = new bytes32[](0); // Empty data array
 
@@ -3388,9 +3411,8 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And empty data array
                 └── Then it should return false
     */
-    function testValidateFlagsAndData_FailsGivenInvalidFlagsWithoutData()
-        public
-    {
+    function testInternalValidateFlagsAndData_FailsGivenInvalidFlagsWithoutData(
+    ) public {
         bytes32 flags = bytes32(uint(2)); // Set invalid bit
         bytes32[] memory data = new bytes32[](0);
 
@@ -3402,7 +3424,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When validating the state transition
                 └── Then it should revert with Module__PP_Queue_InvalidStateTransition
     */
-    function testValidStateTransition_RevertGivenInvalidTransition() public {
+    function testInternalValidStateTransition_RevertGivenInvalidTransition()
+        public
+    {
         vm.expectRevert(
             abi.encodeWithSignature(
                 "Module__PP_Queue_InvalidStateTransition(uint256,uint8,uint8)",
@@ -3423,7 +3447,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When validating the state transitions
                 └── Then they should succeed
     */
-    function testValidStateTransition_SucceedsGivenValidTransitions() public {
+    function testInternalValidStateTransition_worksGivenValidTransitions()
+        public
+    {
         // PENDING -> PROCESSED
         queue.exposed_validStateTransition(
             1,
@@ -3451,9 +3477,8 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── When attempting to claim previously unclaimable amount
                 └── Then it should revert with Module__PP_Queue_NoUnclaimableAmount
     */
-    function testClaimPreviouslyUnclaimable_RevertGivenNoUnclaimableAmount()
-        public
-    {
+    function testInternalClaimPreviouslyUnclaimable_RevertGivenNoUnclaimableAmount(
+    ) public {
         address recipient = makeAddr("recipient");
 
         queue.exposed_claimPreviouslyUnclaimable(
@@ -3471,9 +3496,8 @@ contract PP_Queue_v1_Test is ModuleTest {
                 └── Then it should succeed
     */
 
-    function testClaimPreviouslyUnclaimable_SucceedsGivenUnclaimableAmount()
-        public
-    {
+    function testInternalClaimPreviouslyUnclaimable_worksGivenUnclaimableAmount(
+    ) public {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
 
@@ -3511,7 +3535,9 @@ contract PP_Queue_v1_Test is ModuleTest {
                 └── Then it should revert with Module__PP_Queue_InvalidTargetChain
     */
 
-    function test_validPaymentOrder_failsWithInvalidTargetChain() public {
+    function testInternalValidPaymentOrder_failsWithInvalidTargetChain()
+        public
+    {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
         (bytes32 flags, bytes32[] memory data) =
@@ -3539,7 +3565,7 @@ contract PP_Queue_v1_Test is ModuleTest {
                 └── Then it should return true
     */
 
-    function test_validPaymentOrder_succeedsWithValidOrder() public {
+    function testInternalValidPaymentOrder_succeedsWithValidOrder() public {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
         (bytes32 flags, bytes32[] memory data) =
@@ -3558,15 +3584,15 @@ contract PP_Queue_v1_Test is ModuleTest {
     // Helper Functions
 
     function helper_createTestPaymentOrder(
-        address recipient,
-        uint96 amount,
-        uint orderNum
+        address recipient_,
+        uint96 amount_,
+        uint orderNum_
     ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
         (bytes32 flags, bytes32[] memory data) =
-            helper__encodePaymentOrderData(orderNum);
+            helper__encodePaymentOrderData(orderNum_);
         return IERC20PaymentClientBase_v2.PaymentOrder({
-            recipient: recipient,
-            amount: amount,
+            recipient: recipient_,
+            amount: amount_,
             paymentToken: address(_token),
             originChainId: block.chainid,
             targetChainId: block.chainid,
@@ -3575,34 +3601,34 @@ contract PP_Queue_v1_Test is ModuleTest {
         });
     }
 
-    function helper_setupPaymentTokenBalanceAndApproval(uint96 amount)
+    function helper_setupPaymentTokenBalanceAndApproval(uint96 amount_)
         internal
     {
-        _token.mint(address(paymentClient), amount);
+        _token.mint(address(paymentClient), amount_);
         paymentClient.exposed_addToOutstandingTokenAmounts(
-            address(_token), amount
+            address(_token), amount_
         );
         vm.prank(address(paymentClient));
-        _token.approve(address(queue), amount);
+        _token.approve(address(queue), amount_);
     }
 
     function helper_assertOrderMatch(
-        uint orderId,
-        address client,
-        address expectedRecipient,
-        uint expectedAmount,
-        IPP_Queue_v1.RedemptionState expectedState
+        uint orderId_,
+        address client_,
+        address expectedRecipient_,
+        uint96 expectedAmount_,
+        IPP_Queue_v1.RedemptionState expectedState_
     ) internal {
         IPP_Queue_v1.QueuedOrder memory queuedOrder =
-            queue.getOrder(orderId, IERC20PaymentClientBase_v2(client));
+            queue.getOrder(orderId_, IERC20PaymentClientBase_v2(client_));
         assertEq(
-            queuedOrder.order_.recipient, expectedRecipient, "Wrong recipient"
+            queuedOrder.order_.recipient, expectedRecipient_, "Wrong recipient"
         );
-        assertEq(queuedOrder.order_.amount, expectedAmount, "Wrong amount");
+        assertEq(queuedOrder.order_.amount, expectedAmount_, "Wrong amount");
         assertEq(
             queuedOrder.order_.paymentToken, address(_token), "Wrong token"
         );
-        assertEq(uint(queuedOrder.state_), uint(expectedState), "Wrong state");
+        assertEq(uint(queuedOrder.state_), uint(expectedState_), "Wrong state");
     }
 
     function helper__encodePaymentOrderData(uint orderId_)

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -172,7 +172,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Setup
         _authorizer.setIsAuthorized(address(queue), true);
 
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -188,7 +189,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         paymentClient.addPaymentOrderUnchecked(order);
 
         // Setup tokens using our new helper
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
 
         vm.prank(address(paymentClient));
         uint orderId =
@@ -202,7 +203,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
 
         // Verify order details
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId,
             address(paymentClient),
             recipient_,
@@ -473,7 +474,8 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Initial queue size should be 0."
         );
 
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: makeAddr("recipient"),
@@ -534,7 +536,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         for (uint8 i = 0; i < numOrders_; i++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                _encodePaymentOrderData(i + 1);
+                helper__encodePaymentOrderData(i + 1);
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
                 recipient: makeAddr(string.concat("recipient", vm.toString(i))),
@@ -604,11 +606,11 @@ contract PP_Queue_v1_Test is ModuleTest {
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
             _createTestPaymentOrder(recipient_, amount_, 1);
 
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(this));
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId_,
             address(this),
             recipient_,
@@ -645,13 +647,13 @@ contract PP_Queue_v1_Test is ModuleTest {
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
             _createTestPaymentOrder(recipient_, amount_, 1);
 
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
 
         vm.prank(address(paymentClient));
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId_,
             address(paymentClient),
             recipient_,
@@ -688,7 +690,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetOrder_GivenCancelledOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -718,7 +721,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             orderId_, IERC20PaymentClientBase_v2(address(paymentClient))
         );
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId_,
             address(paymentClient),
             recipient_,
@@ -738,7 +741,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetOrder_GivenProcessedOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -762,7 +766,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
         queue.exposed_removeFromQueue(orderId_, address(paymentClient));
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId_,
             address(paymentClient),
             recipient_,
@@ -793,7 +797,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
             _createTestPaymentOrder(recipient_, amount_, 1);
 
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(this));
 
@@ -820,7 +824,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             IERC20PaymentClientBase_v2.PaymentOrder memory order =
                 _createTestPaymentOrder(recipient_, amount_, i_ + 1);
 
-            _setupPaymentTokenBalanceAndApproval(amount_);
+            helper_setupPaymentTokenBalanceAndApproval(amount_);
 
             vm.prank(address(paymentClient));
             orderIds_[i_] = queue.exposed_addPaymentOrderToQueue(
@@ -889,7 +893,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testQueueOperations_GivenValidInputs() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -950,7 +955,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetQueueHead_GivenSingleOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -984,7 +990,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1012,7 +1019,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             firstOrderId_,
             "Head should be first order ID."
         );
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             firstOrderId_,
             address(paymentClient),
             recipient_,
@@ -1021,7 +1028,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1059,7 +1067,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1083,7 +1092,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1116,7 +1126,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Head should be second order ID."
         );
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             secondOrderId_,
             address(paymentClient),
             recipient_,
@@ -1135,7 +1145,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1159,7 +1170,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1222,7 +1234,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetQueueTail_GivenSingleOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1256,7 +1269,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1278,7 +1292,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1306,7 +1321,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             lastOrderId_,
             "Tail should be last order ID."
         );
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             lastOrderId_,
             address(paymentClient),
             recipient_,
@@ -1325,7 +1340,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1349,7 +1365,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1382,7 +1399,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Tail should be last order ID."
         );
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             lastOrderId_,
             address(paymentClient),
             recipient_,
@@ -1401,7 +1418,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1425,7 +1443,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1497,7 +1516,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             _createTestPaymentOrder(recipient_, amount_, 1);
 
         // Setup tokens using helper
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
 
         vm.prank(address(paymentClient));
 
@@ -1516,7 +1535,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testProcessNextOrder_GivenEmptyQueue() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1554,7 +1574,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             _createTestPaymentOrder(recipient_, amount_, 1);
 
         // Setup tokens using helper
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
 
         // Add order to queue
         queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
@@ -1581,7 +1601,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testExecutePaymentTransfer_RevertGivenInvalidOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(0);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1614,7 +1635,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1660,7 +1682,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testOrderExists_GivenValidOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1707,7 +1730,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testOrderExists_GivenInvalidClient() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1741,7 +1765,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testValidQueueId_GivenValidId() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1781,7 +1806,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
             _createTestPaymentOrder(recipient_, amount_, 1);
 
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
 
@@ -1817,7 +1842,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
             _createTestPaymentOrder(recipient_, amount_, 1);
 
-        _setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
 
@@ -2164,7 +2189,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Add orders to queue
         for (uint i_; i_ < 3; i_++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                _encodePaymentOrderData(i_ + 1);
+                helper__encodePaymentOrderData(i_ + 1);
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2238,7 +2263,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Add orders to queue
         for (uint i_; i_ < 3; i_++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                _encodePaymentOrderData(i_ + 1);
+                helper__encodePaymentOrderData(i_ + 1);
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2278,7 +2303,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Setup: Create a payment order
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2342,7 +2368,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
 
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2388,7 +2415,8 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
 
-        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2436,7 +2464,8 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Cancelled order should return true."
         );
 
-        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) =
+            helper__encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2472,7 +2501,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testProcessNextOrder_RevertGivenInsufficientBalance() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2519,7 +2549,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testUpdateOrderState_RevertGivenInvalidTransition() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) =
+            helper__encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2671,7 +2702,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Payment client should have no tokens"
         );
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId_,
             address(paymentClient),
             recipient,
@@ -2733,7 +2764,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Payment client should have no tokens"
         );
 
-        _assertOrderMatch(
+        helper_assertOrderMatch(
             orderId_,
             address(paymentClient),
             recipient,
@@ -3447,7 +3478,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount = 100;
 
         // Setup: give tokens to payment client and approve queue to spend them
-        _setupPaymentTokenBalanceAndApproval(amount);
+        helper_setupPaymentTokenBalanceAndApproval(amount);
 
         // Transfer tokens to the queue contract first (simulating failed payment flow)
         vm.prank(address(paymentClient));
@@ -3483,7 +3514,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function test_validPaymentOrder_failsWithInvalidTargetChain() public {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
-        (bytes32 flags, bytes32[] memory data) = _encodePaymentOrderData(1);
+        (bytes32 flags, bytes32[] memory data) =
+            helper__encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory invalidOrder =
         IERC20PaymentClientBase_v2.PaymentOrder({
@@ -3510,7 +3542,8 @@ contract PP_Queue_v1_Test is ModuleTest {
     function test_validPaymentOrder_succeedsWithValidOrder() public {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
-        (bytes32 flags, bytes32[] memory data) = _encodePaymentOrderData(1);
+        (bytes32 flags, bytes32[] memory data) =
+            helper__encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory validOrder =
             _createTestPaymentOrder(recipient, amount, 1);
@@ -3530,7 +3563,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint orderNum
     ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
         (bytes32 flags, bytes32[] memory data) =
-            _encodePaymentOrderData(orderNum);
+            helper__encodePaymentOrderData(orderNum);
         return IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient,
             amount: amount,
@@ -3542,7 +3575,9 @@ contract PP_Queue_v1_Test is ModuleTest {
         });
     }
 
-    function _setupPaymentTokenBalanceAndApproval(uint96 amount) internal {
+    function helper_setupPaymentTokenBalanceAndApproval(uint96 amount)
+        internal
+    {
         _token.mint(address(paymentClient), amount);
         paymentClient.exposed_addToOutstandingTokenAmounts(
             address(_token), amount
@@ -3551,7 +3586,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         _token.approve(address(queue), amount);
     }
 
-    function _assertOrderMatch(
+    function helper_assertOrderMatch(
         uint orderId,
         address client,
         address expectedRecipient,
@@ -3570,7 +3605,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         assertEq(uint(queuedOrder.state_), uint(expectedState), "Wrong state");
     }
 
-    function _encodePaymentOrderData(uint orderId_)
+    function helper__encodePaymentOrderData(uint orderId_)
         internal
         pure
         returns (bytes32 flags_, bytes32[] memory data_)

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -189,7 +189,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         paymentClient.addPaymentOrderUnchecked(order);
 
         // Setup tokens using our new helper
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
 
         vm.prank(address(paymentClient));
         uint orderId =
@@ -604,9 +604,9 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(this));
 
@@ -645,9 +645,9 @@ contract PP_Queue_v1_Test is ModuleTest {
         amount_ = uint96(bound(uint(amount_), 1, 1e30));
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
 
         vm.prank(address(paymentClient));
         uint orderId_ =
@@ -795,9 +795,9 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(this));
 
@@ -822,9 +822,11 @@ contract PP_Queue_v1_Test is ModuleTest {
             uint96 amount_ = 100;
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order =
-                helper_createTestPaymentOrder(recipient_, amount_, i_ + 1);
+            helper_createTestPaymentOrder(
+                recipient_, amount_, i_ + 1, address(_token)
+            );
 
-            helper_setupPaymentTokenBalanceAndApproval(amount_);
+            helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
 
             vm.prank(address(paymentClient));
             orderIds_[i_] = queue.exposed_addPaymentOrderToQueue(
@@ -1513,10 +1515,10 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
         // Setup tokens using helper
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
 
         vm.prank(address(paymentClient));
 
@@ -1559,6 +1561,127 @@ contract PP_Queue_v1_Test is ModuleTest {
         assertFalse(success_, "Processing empty queue should fail.");
     }
 
+    /* Test: Function _executePaymentTransfer()
+        ├── Given the payment transfer succeeds
+        │   └── When the function _executePaymentTransfer() is called
+        │       ├── Then the order state is set to PROCESSED
+        │       └── And the order is removed from the queue
+        └── Given the payment transfer fails (receiver blacklisted)
+            └── When the function _executePaymentTransfer() is called
+                ├── Then the order state is set to FAILED
+                └── And the order is removed from the queue
+    */
+
+    function testInternalExecutePaymentTransfer_worksGivenStateIsProcessedAndRemovedFromQueue(
+        address recipient_,
+        uint96 amount_
+    ) public {
+        // Setup
+        recipient_ = helper_validPaymentReceiver(recipient_);
+        vm.assume(amount_ > 0);
+        uint queueId = 1;
+
+        // Create payment order
+        IERC20PaymentClientBase_v2.PaymentOrder memory order =
+        helper_createTestPaymentOrder(
+            recipient_, amount_, queueId, address(_token)
+        );
+        // Mint tokens to payment client and approve PP Queue
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
+
+        // Get value for pre-assertions
+        uint orderId_ =
+            helper_addPaymentOrderToQueue(order, address(paymentClient));
+        uint queueSize_ = queue.getQueueSizeForClient(address(paymentClient));
+        IPP_Queue_v1.QueuedOrder memory queuedOrder_ = queue.getOrder(
+            orderId_, IERC20PaymentClientBase_v2(address(paymentClient))
+        );
+
+        // pre-assertions
+        assertEq(
+            uint(queuedOrder_.state_),
+            uint(IPP_Queue_v1.RedemptionState.PENDING)
+        );
+        assertEq(_token.balanceOf(recipient_), 0);
+        assertEq(queueSize_, 1);
+
+        // Test
+        queue.exposed_executePaymentTransfer(orderId_, queuedOrder_);
+
+        // Get values for post-assertions
+        queuedOrder_ = queue.getOrder(
+            orderId_, IERC20PaymentClientBase_v2(address(paymentClient))
+        );
+        queueSize_ = queue.getQueueSizeForClient(address(paymentClient));
+
+        // post-assertions
+        assertEq(
+            uint(queuedOrder_.state_),
+            uint(IPP_Queue_v1.RedemptionState.PROCESSED)
+        );
+        assertEq(_token.balanceOf(recipient_), amount_);
+        assertEq(queueSize_, 0);
+    }
+
+    function testInternalExecutePaymentTransfer_worksGivenStateIsFailedAndRemovedFromQueue(
+        address recipient_,
+        uint96 amount_
+    ) public {
+        // Setup
+        recipient_ = helper_validPaymentReceiver(recipient_);
+        vm.assume(amount_ > 0);
+        uint queueId = 1;
+
+        // Use non-standard token to blacklist recipient so the transfer state
+        // will be set to fail
+        NonStandardTokenMock nonStandardToken = new NonStandardTokenMock();
+        nonStandardToken.setFailTransferTo(recipient_);
+
+        // Create payment order
+        IERC20PaymentClientBase_v2.PaymentOrder memory order =
+        helper_createTestPaymentOrder(
+            recipient_, amount_, queueId, address(nonStandardToken)
+        );
+        // Mint tokens to payment client and approve PP Queue
+        helper_setupPaymentTokenBalanceAndApproval(
+            amount_, ERC20Mock(address(nonStandardToken))
+        );
+
+        // Get value for pre-assertions
+        uint orderId_ =
+            helper_addPaymentOrderToQueue(order, address(paymentClient));
+        uint queueSize_ = queue.getQueueSizeForClient(address(paymentClient));
+        IPP_Queue_v1.QueuedOrder memory queuedOrder_ = queue.getOrder(
+            orderId_, IERC20PaymentClientBase_v2(address(paymentClient))
+        );
+
+        // pre-assertions
+        assertEq(
+            uint(queuedOrder_.state_),
+            uint(IPP_Queue_v1.RedemptionState.PENDING)
+        );
+        assertEq(nonStandardToken.balanceOf(recipient_), 0);
+        assertEq(nonStandardToken.balanceOf(address(paymentClient)), amount_);
+        assertEq(queueSize_, 1);
+
+        // Test
+        queue.exposed_executePaymentTransfer(orderId_, queuedOrder_);
+
+        // Get values for post-assertions
+        queuedOrder_ = queue.getOrder(
+            orderId_, IERC20PaymentClientBase_v2(address(paymentClient))
+        );
+        queueSize_ = queue.getQueueSizeForClient(address(paymentClient));
+
+        // post-assertions
+        assertEq(
+            uint(queuedOrder_.state_), uint(IPP_Queue_v1.RedemptionState.FAILED)
+        );
+        assertEq(nonStandardToken.balanceOf(recipient_), 0);
+        assertEq(nonStandardToken.balanceOf(address(queue)), amount_);
+        assertEq(queueSize_, 0);
+    }
+
     /* Test testExecutePaymentTransfer_GivenValidOrder()
         └── Given a valid payment order
             └── When executing transfer
@@ -1571,10 +1694,10 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
         // Setup tokens using helper
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
 
         // Add order to queue
         queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
@@ -1804,9 +1927,9 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
 
@@ -1840,9 +1963,9 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
-        helper_setupPaymentTokenBalanceAndApproval(amount_);
+        helper_setupPaymentTokenBalanceAndApproval(amount_, _token);
         uint orderId_ =
             queue.exposed_addPaymentOrderToQueue(order, address(paymentClient));
 
@@ -2140,7 +2263,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
         _token.mint(address(paymentClient), amount_ * 2);
 
@@ -2668,7 +2791,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount = 1000;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
-            helper_createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1, address(_token));
         // Setup initial state
         _token.mint(address(paymentClient), amount);
         paymentClient.exposed_addToOutstandingTokenAmounts(
@@ -2728,7 +2851,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount = 1000;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory orders =
-            helper_createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1, address(_token));
 
         // Setup initial state
         _token.mint(address(paymentClient), amount);
@@ -2796,7 +2919,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
         _token.mint(address(paymentClient), amount_ * 2);
 
@@ -2841,7 +2964,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
-            helper_createTestPaymentOrder(recipient_, amount_, 1);
+        helper_createTestPaymentOrder(recipient_, amount_, 1, address(_token));
 
         _token.mint(address(paymentClient), amount_ * 2);
 
@@ -2980,7 +3103,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
         IERC20PaymentClientBase_v2.PaymentOrder memory validOrder =
-            helper_createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1, address(_token));
 
         assertTrue(
             queue.validPaymentOrder(validOrder),
@@ -2988,14 +3111,15 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
 
         IERC20PaymentClientBase_v2.PaymentOrder memory invalidOrder =
-            helper_createTestPaymentOrder(address(0), amount, 1);
+        helper_createTestPaymentOrder(address(0), amount, 1, address(_token));
 
         assertFalse(
             queue.validPaymentOrder(invalidOrder),
             "Payment order with zero address recipient should return false"
         );
 
-        invalidOrder = helper_createTestPaymentOrder(recipient, 0, 1);
+        invalidOrder =
+            helper_createTestPaymentOrder(recipient, 0, 1, address(_token));
 
         assertFalse(
             queue.validPaymentOrder(invalidOrder),
@@ -3449,6 +3573,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     */
     function testInternalValidStateTransition_worksGivenValidTransitions()
         public
+        view
     {
         // PENDING -> PROCESSED
         queue.exposed_validStateTransition(
@@ -3502,7 +3627,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount = 100;
 
         // Setup: give tokens to payment client and approve queue to spend them
-        helper_setupPaymentTokenBalanceAndApproval(amount);
+        helper_setupPaymentTokenBalanceAndApproval(amount, _token);
 
         // Transfer tokens to the queue contract first (simulating failed payment flow)
         vm.prank(address(paymentClient));
@@ -3514,7 +3639,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         // Now add it as unclaimable
         queue.exposed_addUnclaimableOrder(
-            helper_createTestPaymentOrder(recipient, amount, 1),
+            helper_createTestPaymentOrder(recipient, amount, 1, address(_token)),
             address(paymentClient)
         );
 
@@ -3568,11 +3693,9 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testInternalValidPaymentOrder_succeedsWithValidOrder() public {
         address recipient = makeAddr("recipient");
         uint96 amount = 100;
-        (bytes32 flags, bytes32[] memory data) =
-            helper__encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory validOrder =
-            helper_createTestPaymentOrder(recipient, amount, 1);
+            helper_createTestPaymentOrder(recipient, amount, 1, address(_token));
 
         assertTrue(
             queue.exposed_validPaymentOrder(validOrder),
@@ -3583,17 +3706,32 @@ contract PP_Queue_v1_Test is ModuleTest {
     // ================================================================================
     // Helper Functions
 
+    function helper_validPaymentReceiver(address recipient_)
+        internal
+        view
+        returns (address)
+    {
+        vm.assume(
+            recipient_ != address(0) && recipient_ != address(queue)
+                && recipient_ != address(this) && recipient_ != address(_token)
+                && recipient_ != address(_orchestrator)
+                && recipient_ != address(paymentClient)
+        );
+        return recipient_;
+    }
+
     function helper_createTestPaymentOrder(
         address recipient_,
         uint96 amount_,
-        uint orderNum_
+        uint orderNum_,
+        address token_
     ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
         (bytes32 flags, bytes32[] memory data) =
             helper__encodePaymentOrderData(orderNum_);
         return IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
             amount: amount_,
-            paymentToken: address(_token),
+            paymentToken: address(token_),
             originChainId: block.chainid,
             targetChainId: block.chainid,
             flags: flags,
@@ -3601,15 +3739,23 @@ contract PP_Queue_v1_Test is ModuleTest {
         });
     }
 
-    function helper_setupPaymentTokenBalanceAndApproval(uint96 amount_)
-        internal
-    {
-        _token.mint(address(paymentClient), amount_);
+    function helper_addPaymentOrderToQueue(
+        IERC20PaymentClientBase_v2.PaymentOrder memory order_,
+        address client_
+    ) internal returns (uint queueId_) {
+        queueId_ = queue.exposed_addPaymentOrderToQueue(order_, client_);
+    }
+
+    function helper_setupPaymentTokenBalanceAndApproval(
+        uint96 amount_,
+        ERC20Mock token_
+    ) internal {
+        token_.mint(address(paymentClient), amount_);
         paymentClient.exposed_addToOutstandingTokenAmounts(
-            address(_token), amount_
+            address(token_), amount_
         );
         vm.prank(address(paymentClient));
-        _token.approve(address(queue), amount_);
+        token_.approve(address(queue), amount_);
     }
 
     function helper_assertOrderMatch(

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -3025,25 +3025,6 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
     }
 
-    function helper_encodePaymentOrderData(uint orderId_)
-        internal
-        pure
-        returns (bytes32 flags_, bytes32[] memory data_)
-    {
-        bytes32 _flags;
-        _flags = 0;
-
-        uint8[] memory flags = new uint8[](1); // The Module will use 1 flag
-        flags[0] = 0;
-
-        _flags |= bytes32((1 << flags[0]));
-
-        bytes32[] memory paymentParameters = new bytes32[](1);
-        paymentParameters[0] = bytes32(orderId_);
-
-        return (_flags, paymentParameters);
-    }
-
     /* Test: Function _getProtocolFeeDetails()
         └── Given valid protocol fee amount
             ├── And total amount is to low such that rounding results in zero fee amount
@@ -3108,6 +3089,174 @@ contract PP_Queue_v1_Test is ModuleTest {
         assertEq(treasury, expectedTreasury, "Treasury should be correct");
     }
 
+    /* Test testValidChainId_GivenValidAndInvalidIds()
+        └── Given chain IDs
+            └── When validating chain IDs
+                ├── Then current chain ID should return true
+                ├── Then different chain ID should return false
+                └── Then zero chain ID should return false
+    */
+
+    function testValidChainId_GivenValidAndInvalidIds(uint chainId_) public {
+        // Bound the chainId to a reasonable range to avoid overflow
+        chainId_ = bound(chainId_, 0, type(uint128).max);
+
+        // Test current chain ID
+        assertTrue(
+            queue.exposed_validChainId(block.chainid),
+            "Current chain ID should be valid"
+        );
+
+        // Test different chain ID
+        vm.assume(chainId_ != block.chainid);
+        assertFalse(
+            queue.exposed_validChainId(chainId_),
+            "Different chain ID should be invalid"
+        );
+
+        // Test zero chain ID
+        assertFalse(
+            queue.exposed_validChainId(0), "Zero chain ID should be invalid"
+        );
+    }
+
+    /* Test testLowLevelTransfer_GivenValidInputs()
+        └── Given valid transfer inputs
+            └── When performing low level transfer
+                ├── Then successful transfer should work
+                ├── Then insufficient balance should fail
+                ├── Then non-contract token should fail
+                └── Then zero address token should fail
+    */
+    function testLowLevelTransfer_GivenValidInputs() public {
+        // Setup
+        address client = makeAddr("client");
+        address recipient = makeAddr("recipient");
+        uint amount = 100;
+
+        // Setup token balances and allowances
+        _token.mint(client, amount);
+        vm.prank(client);
+        _token.approve(address(queue), amount);
+
+        // Test successful transfer
+        bool success = queue.exposed_lowLevelTransfer(
+            address(_token), client, recipient, amount
+        );
+        assertTrue(success, "Transfer should succeed");
+        assertEq(
+            _token.balanceOf(recipient),
+            amount,
+            "Recipient should receive amount"
+        );
+        assertEq(_token.balanceOf(client), 0, "Client balance should be zero");
+
+        // Test failed transfer (insufficient balance)
+        success = queue.exposed_lowLevelTransfer(
+            address(_token), client, recipient, amount
+        );
+        assertFalse(success, "Transfer should fail with insufficient balance");
+
+        // Test with non-contract token
+        success = queue.exposed_lowLevelTransfer(
+            address(0x789), client, recipient, amount
+        );
+        assertFalse(success, "Transfer should fail with non-contract token");
+
+        // Test with zero address
+        success = queue.exposed_lowLevelTransfer(
+            address(0), client, recipient, amount
+        );
+        assertFalse(success, "Transfer should fail with zero address token");
+    }
+
+    /* Test testLowLevelTransfer_GivenInvalidToken()
+        └── Given invalid token contracts
+            └── When performing low level transfer
+                ├── Then non-ERC20 contract should fail
+                └── Then invalid transfer contract should fail
+    */
+    function testLowLevelTransfer_GivenInvalidToken() public {
+        // Setup
+        address client = makeAddr("client");
+        address recipient = makeAddr("recipient");
+        uint amount = 100;
+
+        // Test with non-ERC20 contract
+        address nonERC20Contract = address(new NonERC20Contract());
+        bool success = queue.exposed_lowLevelTransfer(
+            nonERC20Contract, client, recipient, amount
+        );
+        assertFalse(success, "Transfer should fail with non-ERC20 contract");
+
+        // Test with contract that doesn't implement transferFrom
+        address invalidContract = address(new InvalidTransferContract());
+        success = queue.exposed_lowLevelTransfer(
+            invalidContract, client, recipient, amount
+        );
+        assertFalse(
+            success, "Transfer should fail with invalid transfer contract"
+        );
+    }
+
+    // ================================================================================
+    // Test Ensure Valid Client
+
+    /* Test testEnsureValidClient_GivenValidClient()
+        └── Given a valid client address that is:
+            ├── Not address(0)
+            ├── Not queue address
+            └── Not orchestrator address
+                └── When caller is the client
+                    └── Then it should succeed
+    */
+    function testEnsureValidClient_GivenValidClient(address client_) public {
+        vm.assume(client_ != address(0));
+        vm.assume(client_ != address(queue));
+        vm.assume(client_ != address(_orchestrator));
+        vm.assume(client_ != address(this));
+
+        vm.prank(client_);
+        queue.exposed_ensureValidClient(client_);
+    }
+
+    /* Test testEnsureValidClient_RevertGivenInvalidClient()
+        └── Given an invalid client address
+            └── When checking client validity
+                ├── Then it should revert with Module__PP_Queue_InvalidClientAddress for zero address
+                └── Then it should revert with Module__PP_Queue_InvalidClientAddress for queue address
+    */
+    function testEnsureValidClient_RevertGivenInvalidClient() public {
+        vm.expectRevert();
+        queue.exposed_ensureValidClient(address(0));
+
+        vm.expectRevert();
+
+        queue.exposed_ensureValidClient(address(queue));
+    }
+
+    /* Test testEnsureValidClient_RevertGivenNonClientCaller()
+        └── Given a valid client address
+            └── When caller is not the client
+                └── Then it should revert with Module__PP_Queue_OnlyCallableByClient
+    */
+    function testEnsureValidClient_RevertGivenNonClientCaller(
+        address client_,
+        address caller_
+    ) public {
+        vm.assume(client_ != address(0));
+        vm.assume(client_ != address(queue));
+        vm.assume(client_ != address(_orchestrator));
+        vm.assume(client_ != caller_);
+        vm.assume(caller_ != address(0));
+
+        vm.prank(caller_);
+        vm.expectRevert(
+            abi.encodeWithSignature("Module__PP_Queue_OnlyCallableByClient()")
+        );
+        queue.exposed_ensureValidClient(client_);
+    }
+
     // ================================================================================
     // Helper Functions
 
@@ -3155,5 +3304,40 @@ contract PP_Queue_v1_Test is ModuleTest {
             queuedOrder.order_.paymentToken, address(_token), "Wrong token"
         );
         assertEq(uint(queuedOrder.state_), uint(expectedState), "Wrong state");
+    }
+
+    function helper_encodePaymentOrderData(uint orderId_)
+        internal
+        pure
+        returns (bytes32 flags_, bytes32[] memory data_)
+    {
+        bytes32 _flags;
+        _flags = 0;
+
+        uint8[] memory flags = new uint8[](1); // The Module will use 1 flag
+        flags[0] = 0;
+
+        _flags |= bytes32((1 << flags[0]));
+
+        bytes32[] memory paymentParameters = new bytes32[](1);
+        paymentParameters[0] = bytes32(orderId_);
+
+        return (_flags, paymentParameters);
+    }
+}
+
+// Mock contracts for testing
+contract NonERC20Contract {
+// This contract doesn't implement any ERC20 functions
+}
+
+contract InvalidTransferContract {
+    // This contract implements transferFrom but returns false
+    function transferFrom(address, address, uint)
+        external
+        pure
+        returns (bool)
+    {
+        return false;
     }
 }

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -3406,6 +3406,55 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testEnsureValidPaymentToken_RevertGivenInvalidToken() public {
         assertFalse(queue.exposed_validPaymentToken(address(0)));
     }
+
+    /* Test testValidateFlagsAndData_GivenValidFlagsAndData()
+        └── Given valid flags with ORDER_ID bit set
+            └── And data array with order ID
+                └── Then it should return true
+    */
+    function testValidateFlagsAndData_GivenValidFlagsAndData() public {
+        bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
+        bytes32[] memory data = new bytes32[](1);
+        data[0] = bytes32(uint(123)); // Some order ID
+
+        assertTrue(queue.exposed_validateFlagsAndData(flags, data));
+    }
+
+    /* Test testValidateFlagsAndData_GivenValidFlagsWithoutData()
+        └── Given valid flags without ORDER_ID bit set
+            └── And empty data array
+                └── Then it should return true
+    */
+    function testValidateFlagsAndData_GivenValidFlagsWithoutData() public {
+        bytes32 flags = bytes32(uint(0)); // No bits set
+        bytes32[] memory data = new bytes32[](0);
+
+        assertFalse(queue.exposed_validateFlagsAndData(flags, data));
+    }
+
+    /* Test testValidateFlagsAndData_GivenInvalidFlagsWithData()
+        └── Given flags with ORDER_ID bit set
+            └── And empty data array
+                └── Then it should return false
+    */
+    function testValidateFlagsAndData_GivenInvalidFlagsWithData() public {
+        bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
+        bytes32[] memory data = new bytes32[](0); // Empty data array
+
+        assertFalse(queue.exposed_validateFlagsAndData(flags, data));
+    }
+
+    /* Test testValidateFlagsAndData_GivenInvalidFlagsWithoutData()
+        └── Given flags with invalid bits set
+            └── And empty data array
+                └── Then it should return false
+    */
+    function testValidateFlagsAndData_GivenInvalidFlagsWithoutData() public {
+        bytes32 flags = bytes32(uint(2)); // Set invalid bit
+        bytes32[] memory data = new bytes32[](0);
+
+        assertFalse(queue.exposed_validateFlagsAndData(flags, data));
+    }
 }
 
 // Mock contracts for testing

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -3324,6 +3324,88 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         return (_flags, paymentParameters);
     }
+
+    /* Test testSetCanceledOrdersTreasury_GivenValidAddress()
+        └── Given a valid treasury address
+            └── When setting the canceled orders treasury
+                └── Then it should be set correctly
+    */
+    function testSetCanceledOrdersTreasury_GivenValidAddress() public {
+        address newTreasury = makeAddr("newTreasury");
+
+        queue.exposed_setCanceledOrdersTreasury(newTreasury);
+
+        // Verify the treasury was set correctly by checking the queue's state
+        assertEq(
+            queue.getCanceledOrdersTreasury(),
+            newTreasury,
+            "Canceled orders treasury should be updated"
+        );
+    }
+
+    /* Test testSetCanceledOrdersTreasury_RevertGivenZeroAddress()
+        └── Given a zero address
+            └── When setting the canceled orders treasury
+                └── Then it should revert
+    */
+    function testSetCanceledOrdersTreasury_RevertGivenZeroAddress() public {
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "Module__PP_Queue_InvalidTreasuryAddress(address)", address(0)
+            )
+        );
+        queue.exposed_setCanceledOrdersTreasury(address(0));
+    }
+
+    /* Test testSetFailedOrdersTreasury_GivenValidAddress()
+        └── Given a valid treasury address
+            └── When setting the failed orders treasury
+                └── Then it should be set correctly
+    */
+    function testSetFailedOrdersTreasury_GivenValidAddress() public {
+        address newTreasury = makeAddr("newTreasury");
+
+        queue.exposed_setFailedOrdersTreasury(newTreasury);
+
+        // Verify the treasury was set correctly by checking the queue's state
+        assertEq(
+            queue.getFailedOrdersTreasury(),
+            newTreasury,
+            "Failed orders treasury should be updated"
+        );
+    }
+
+    /* Test testSetFailedOrdersTreasury_RevertGivenZeroAddress()
+        └── Given a zero address
+            └── When setting the failed orders treasury
+                └── Then it should revert
+    */
+    function testSetFailedOrdersTreasury_RevertGivenZeroAddress() public {
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "Module__PP_Queue_InvalidTreasuryAddress(address)", address(0)
+            )
+        );
+        queue.exposed_setFailedOrdersTreasury(address(0));
+    }
+
+    /* Test testEnsureValidPaymentToken_GivenValidToken()
+        └── Given a valid payment token
+            └── And the token is not address(0)
+                └── Then it should return true
+    */
+    function testEnsureValidPaymentToken_GivenValidToken() public {
+        assertTrue(queue.exposed_validPaymentToken(address(_token)));
+    }
+
+    /* Test testEnsureValidPaymentToken_RevertGivenInvalidToken()
+        └── Given an invalid payment token
+            └── When ensuring valid payment token
+                └── Then it should revert
+    */
+    function testEnsureValidPaymentToken_RevertGivenInvalidToken() public {
+        assertFalse(queue.exposed_validPaymentToken(address(0)));
+    }
 }
 
 // Mock contracts for testing

--- a/test/modules/paymentProcessor/PP_Queue_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Queue_v1.t.sol
@@ -172,8 +172,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Setup
         _authorizer.setIsAuthorized(address(queue), true);
 
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -474,8 +473,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Initial queue size should be 0."
         );
 
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: makeAddr("recipient"),
@@ -536,7 +534,7 @@ contract PP_Queue_v1_Test is ModuleTest {
 
         for (uint8 i = 0; i < numOrders_; i++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                helper_encodePaymentOrderData(i + 1);
+                _encodePaymentOrderData(i + 1);
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
                 recipient: makeAddr(string.concat("recipient", vm.toString(i))),
@@ -690,8 +688,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetOrder_GivenCancelledOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -741,8 +738,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetOrder_GivenProcessedOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -893,8 +889,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testQueueOperations_GivenValidInputs() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -955,8 +950,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetQueueHead_GivenSingleOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -990,8 +984,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1028,8 +1021,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1067,8 +1059,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1092,8 +1083,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1145,8 +1135,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1170,8 +1159,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1234,8 +1222,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testGetQueueTail_GivenSingleOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1269,8 +1256,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1292,8 +1278,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1340,8 +1325,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1365,8 +1349,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1418,8 +1401,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint96 amount_ = 100;
 
         // First order
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1443,8 +1425,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         vm.stopPrank();
 
         // Second order with different flags/data
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1535,8 +1516,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testProcessNextOrder_GivenEmptyQueue() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1601,8 +1581,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testExecutePaymentTransfer_RevertGivenInvalidOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(0);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(0);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1635,8 +1614,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1682,8 +1660,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testOrderExists_GivenValidOrder() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1730,8 +1707,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testOrderExists_GivenInvalidClient() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -1765,8 +1741,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testValidQueueId_GivenValidId() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2189,7 +2164,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Add orders to queue
         for (uint i_; i_ < 3; i_++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                helper_encodePaymentOrderData(i_ + 1);
+                _encodePaymentOrderData(i_ + 1);
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2263,7 +2238,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Add orders to queue
         for (uint i_; i_ < 3; i_++) {
             (bytes32 flags_, bytes32[] memory data_) =
-                helper_encodePaymentOrderData(i_ + 1);
+                _encodePaymentOrderData(i_ + 1);
 
             IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
             IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2303,8 +2278,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         // Setup: Create a payment order
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
 
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
@@ -2368,8 +2342,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
 
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2415,8 +2388,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
 
-        (bytes32 flags1_, bytes32[] memory data1_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags1_, bytes32[] memory data1_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order1_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2464,8 +2436,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             "Cancelled order should return true."
         );
 
-        (bytes32 flags2_, bytes32[] memory data2_) =
-            helper_encodePaymentOrderData(2);
+        (bytes32 flags2_, bytes32[] memory data2_) = _encodePaymentOrderData(2);
         IERC20PaymentClientBase_v2.PaymentOrder memory order2_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2501,8 +2472,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testProcessNextOrder_RevertGivenInsufficientBalance() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -2549,8 +2519,7 @@ contract PP_Queue_v1_Test is ModuleTest {
     function testUpdateOrderState_RevertGivenInvalidTransition() public {
         address recipient_ = makeAddr("recipient");
         uint96 amount_ = 100;
-        (bytes32 flags_, bytes32[] memory data_) =
-            helper_encodePaymentOrderData(1);
+        (bytes32 flags_, bytes32[] memory data_) = _encodePaymentOrderData(1);
         IERC20PaymentClientBase_v2.PaymentOrder memory order_ =
         IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient_,
@@ -3331,7 +3300,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And the token is not address(0)
                 └── Then it should return true
     */
-    function testEnsureValidPaymentToken_GivenValidToken() public {
+    function testEnsureValidPaymentToken_SucceedsGivenValidToken() public {
         assertTrue(queue.exposed_validPaymentToken(address(_token)));
     }
 
@@ -3349,7 +3318,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And data array with order ID
                 └── Then it should return true
     */
-    function testValidateFlagsAndData_GivenValidFlagsAndData() public {
+    function testValidateFlagsAndData_SucceedsGivenValidFlagsAndData() public {
         bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
         bytes32[] memory data = new bytes32[](1);
         data[0] = bytes32(uint(123)); // Some order ID
@@ -3362,7 +3331,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And empty data array
                 └── Then it should return true
     */
-    function testValidateFlagsAndData_GivenValidFlagsWithoutData() public {
+    function testValidateFlagsAndData_SucceedsGivenValidFlagsWithoutData()
+        public
+    {
         bytes32 flags = bytes32(uint(0)); // No bits set
         bytes32[] memory data = new bytes32[](0);
 
@@ -3374,7 +3345,7 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And empty data array
                 └── Then it should return false
     */
-    function testValidateFlagsAndData_GivenInvalidFlagsWithData() public {
+    function testValidateFlagsAndData_FailsGivenInvalidFlagsWithData() public {
         bytes32 flags = bytes32(uint(1)); // Set ORDER_ID bit
         bytes32[] memory data = new bytes32[](0); // Empty data array
 
@@ -3386,7 +3357,9 @@ contract PP_Queue_v1_Test is ModuleTest {
             └── And empty data array
                 └── Then it should return false
     */
-    function testValidateFlagsAndData_GivenInvalidFlagsWithoutData() public {
+    function testValidateFlagsAndData_FailsGivenInvalidFlagsWithoutData()
+        public
+    {
         bytes32 flags = bytes32(uint(2)); // Set invalid bit
         bytes32[] memory data = new bytes32[](0);
 
@@ -3442,6 +3415,66 @@ contract PP_Queue_v1_Test is ModuleTest {
         );
     }
 
+    /* Test testClaimPreviouslyUnclaimable_RevertGivenNoUnclaimableAmount()
+        └── Given no unclaimable amount for the client/token/receiver combination
+            └── When attempting to claim previously unclaimable amount
+                └── Then it should revert with Module__PP_Queue_NoUnclaimableAmount
+    */
+    function testClaimPreviouslyUnclaimable_RevertGivenNoUnclaimableAmount()
+        public
+    {
+        address recipient = makeAddr("recipient");
+
+        queue.exposed_claimPreviouslyUnclaimable(
+            address(paymentClient), address(_token), recipient
+        );
+        assertEq(
+            _token.balanceOf(recipient),
+            0,
+            "Recipient should not receive any tokens"
+        );
+    }
+    /* Test testClaimPreviouslyUnclaimable_SucceedsGivenUnclaimableAmount()
+        └── Given unclaimable amount for the client/token/receiver combination
+            └── When attempting to claim previously unclaimable amount
+                └── Then it should succeed
+    */
+
+    function testClaimPreviouslyUnclaimable_SucceedsGivenUnclaimableAmount()
+        public
+    {
+        address recipient = makeAddr("recipient");
+        uint96 amount = 100;
+
+        // Setup: give tokens to payment client and approve queue to spend them
+        _setupPaymentTokenBalanceAndApproval(amount);
+
+        // Transfer tokens to the queue contract first (simulating failed payment flow)
+        vm.prank(address(paymentClient));
+        _token.transfer(address(queue), amount);
+
+        // Queue needs to approve itself to transfer its own tokens
+        vm.prank(address(queue));
+        _token.approve(address(queue), amount);
+
+        // Now add it as unclaimable
+        queue.exposed_addUnclaimableOrder(
+            _createTestPaymentOrder(recipient, amount, 1),
+            address(paymentClient)
+        );
+
+        // Try to claim
+        queue.exposed_claimPreviouslyUnclaimable(
+            address(paymentClient), address(_token), recipient
+        );
+
+        assertEq(
+            _token.balanceOf(recipient),
+            amount,
+            "Recipient should receive tokens"
+        );
+    }
+
     // ================================================================================
     // Helper Functions
 
@@ -3451,7 +3484,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         uint orderNum
     ) internal view returns (IERC20PaymentClientBase_v2.PaymentOrder memory) {
         (bytes32 flags, bytes32[] memory data) =
-            helper_encodePaymentOrderData(orderNum);
+            _encodePaymentOrderData(orderNum);
         return IERC20PaymentClientBase_v2.PaymentOrder({
             recipient: recipient,
             amount: amount,
@@ -3491,7 +3524,7 @@ contract PP_Queue_v1_Test is ModuleTest {
         assertEq(uint(queuedOrder.state_), uint(expectedState), "Wrong state");
     }
 
-    function helper_encodePaymentOrderData(uint orderId_)
+    function _encodePaymentOrderData(uint orderId_)
         internal
         pure
         returns (bytes32 flags_, bytes32[] memory data_)

--- a/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
+++ b/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
@@ -171,4 +171,10 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
     ) external {
         _claimPreviouslyUnclaimable(client_, token_, paymentReceiver_);
     }
+
+    function exposed_validPaymentOrder(
+        IERC20PaymentClientBase_v2.PaymentOrder memory order_
+    ) external view returns (bool) {
+        return _validPaymentOrder(order_);
+    }
 }

--- a/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
+++ b/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
@@ -10,7 +10,6 @@ import {LinkedIdList} from "src/modules/lib/LinkedIdList.sol";
 contract PP_Queue_v1_Exposed is PP_Queue_v1 {
     using LinkedIdList for LinkedIdList.List;
 
-    // Override _msgSender para simplificar testing
     function _msgSender() internal view virtual override returns (address) {
         return msg.sender;
     }
@@ -58,7 +57,6 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
         return _getPaymentQueueId(flags_, data_);
     }
 
-    // Función para exponer _validQueueId
     function exposed_validQueueId(uint queueId, address client_)
         external
         view

--- a/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
+++ b/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
@@ -177,4 +177,11 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
     ) external view returns (bool) {
         return _validPaymentOrder(order_);
     }
+
+    function exposed_executePaymentTransfer(
+        uint orderId_,
+        QueuedOrder memory order_
+    ) external {
+        _executePaymentTransfer(orderId_, order_);
+    }
 }

--- a/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
+++ b/test/modules/paymentProcessor/utils/mocks/PP_Queue_v1_Exposed.sol
@@ -126,4 +126,51 @@ contract PP_Queue_v1_Exposed is PP_Queue_v1 {
             client_, order_.paymentToken, order_.recipient, order_.amount
         );
     }
+
+    function exposed_validChainId(uint chainId_) external view returns (bool) {
+        return _validChainId(chainId_);
+    }
+
+    function exposed_validPaymentToken(address token_)
+        external
+        view
+        returns (bool)
+    {
+        return _validPaymentToken(token_);
+    }
+
+    function exposed_validateFlagsAndData(
+        bytes32 flags_,
+        bytes32[] memory data_
+    ) external pure returns (bool) {
+        return _validateFlagsAndData(flags_, data_);
+    }
+
+    function exposed_validStateTransition(
+        uint orderId_,
+        RedemptionState currentState_,
+        RedemptionState newState_
+    ) external pure returns (bool) {
+        return _validStateTransition(orderId_, currentState_, newState_);
+    }
+
+    function exposed_ensureValidClient(address client_) external view {
+        _ensureValidClient(client_);
+    }
+
+    function exposed_setCanceledOrdersTreasury(address treasury_) external {
+        _setCanceledOrdersTreasury(treasury_);
+    }
+
+    function exposed_setFailedOrdersTreasury(address treasury_) external {
+        _setFailedOrdersTreasury(treasury_);
+    }
+
+    function exposed_claimPreviouslyUnclaimable(
+        address client_,
+        address token_,
+        address paymentReceiver_
+    ) external {
+        _claimPreviouslyUnclaimable(client_, token_, paymentReceiver_);
+    }
 }


### PR DESCRIPTION
This PR exposes internal functions of PP_Queue_v1 and adds comprehensive test coverage:

1. Exposed Internal Functions:
   - Added to PP_Queue_v1_Exposed contract to finish exposing all internal functions from PP_Queue_v1
   - Added exposed_ prefix to maintain clear distinction between internal and exposed functions
   - Enables direct testing of previously internal-only functionality
   - Clean up, inverter standard updates, formatting fixes

The changes significantly improve testability by allowing direct access to internal functions while maintaining the security of the production contract through a separate exposed version for testing.

`exposed_executePaymentTransfer ` still needs coverage but I couldn't figure out how to do it. May need to pay for this or alternatively, you can add it. Seems like an issue with the typecasting.